### PR TITLE
Fixed run.bat files for Windows cmd+PowerShell

### DIFF
--- a/Java/AbstractFactory-Example-Taxes/run.bat
+++ b/Java/AbstractFactory-Example-Taxes/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/AbstractFactory-Example/run.bat
+++ b/Java/AbstractFactory-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Adapter-Pattern-Example/run.bat
+++ b/Java/Adapter-Pattern-Example/run.bat
@@ -1,4 +1,4 @@
-mvn clean compile assembly:single
+call mvn clean compile assembly:single
 
-java -cp target/Example-1-1.0-SNAPSHOT-jar-with-dependencies.jar  edu.bu.met.cs665.Main
+call java -cp target/Example-1-1.0-SNAPSHOT-jar-with-dependencies.jar  edu.bu.met.cs665.Main
 

--- a/Java/CommandPattern-Example/run.bat
+++ b/Java/CommandPattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Composite-Pattern-Example/run.bat
+++ b/Java/Composite-Pattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Decorator-Example/run.bat
+++ b/Java/Decorator-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/E-Mail-Collector-System-Implementing-Decorator-Pattern/run.bat
+++ b/Java/E-Mail-Collector-System-Implementing-Decorator-Pattern/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Example-1/run.bat
+++ b/Java/Example-1/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/FacadePattern-Example/run.bat
+++ b/Java/FacadePattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/FactoryMethod-Example/run.bat
+++ b/Java/FactoryMethod-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/JUnitExamples/run.bat
+++ b/Java/JUnitExamples/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/MVC-Pattern-Example/run.bat
+++ b/Java/MVC-Pattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Mediator-Patter-Example/run.bat
+++ b/Java/Mediator-Patter-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Observer-Pattern/run.bat
+++ b/Java/Observer-Pattern/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/ObserverPattern-OnlineShop-Example/run.bat
+++ b/Java/ObserverPattern-OnlineShop-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/ObserverPattern-TV-Example/run.bat
+++ b/Java/ObserverPattern-TV-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Prototype-Game-Example/bin/run.bat
+++ b/Java/Prototype-Game-Example/bin/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile assembly:single
+call mvn clean compile assembly:single
 
 

--- a/Java/Prototype-Game-Example/run.bat
+++ b/Java/Prototype-Game-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Prototype-Pattern-BankAccounts/run.bat
+++ b/Java/Prototype-Pattern-BankAccounts/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Proxy-Pattern-Example/run.bat
+++ b/Java/Proxy-Pattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Refactoring-Examples/run.bat
+++ b/Java/Refactoring-Examples/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Refactoring-Singleton-Game-Example/bin/run.bat
+++ b/Java/Refactoring-Singleton-Game-Example/bin/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile assembly:single
+call mvn clean compile assembly:single
 
 

--- a/Java/Refactoring-Singleton-Game-Example/run.bat
+++ b/Java/Refactoring-Singleton-Game-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Singleton-Example/run.bat
+++ b/Java/Singleton-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Singleton-Game-Example/bin/run.bat
+++ b/Java/Singleton-Game-Example/bin/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile assembly:single
+call mvn clean compile assembly:single
 
 

--- a/Java/Singleton-Game-Example/run.bat
+++ b/Java/Singleton-Game-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/State-Pattern-Example/run.bat
+++ b/Java/State-Pattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/StatePattern-Agile-Story/run.bat
+++ b/Java/StatePattern-Agile-Story/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Template-Pattern-Example/run.bat
+++ b/Java/Template-Pattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/Visitor-Pattern-Example/run.bat
+++ b/Java/Visitor-Pattern-Example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 

--- a/Java/log4j-example/run.bat
+++ b/Java/log4j-example/run.bat
@@ -1,3 +1,3 @@
-mvn clean compile
-mvn exec:java -Dexec.executable="edu.bu.met.cs665.Main" -Dlog4j.configuration="file:log4j.properties"
+call mvn clean compile
+call mvn exec:java -D"exec.executable"="edu.bu.met.cs665.Main" -D"log4j.configuration"="file:log4j.properties"
 


### PR DESCRIPTION
Hello Professor,

I noticed that when using VSCode, the `run.bat` files don't work. It's because VSCode uses a PowerShell terminal instead of the regular cmd. To make it also work for PowerShell, we need to add quotes around some of the arguments to `mvn`. I wrote a simple Python script to do this, and fixed all the `run.bat` files. I'm creating this pull request to fix it for others who might be facing the same problem.

Sincerely,
Francis

---

PS: The script I used to bulk convert all the files:
```py
import os
import os.path
import sys

DEFAULT_ROOT_DIR = '.'
DEFAULT_SEARCH_FILENAME = 'run.bat'


def get_filenames(root_dir, search_filename):
    result = []
    for (dirpath, dirnames, filenames) in os.walk(root_dir):
        for filename in filenames:
            if filename == search_filename:
                result.append(os.path.join(dirpath, filename))
    return result


def fix_line(line):
    if not line.strip():
        return line
    if not line.startswith('call '):
        line = 'call ' + line
    if '-Dexec.executable=' in line:
        line = line.replace('-Dexec.executable=', '-D"exec.executable"=')
    if '-Dlog4j.configuration=' in line:
        line = line.replace('-Dlog4j.configuration=', '-D"log4j.configuration"=')
    return line


def main():
    filenames = get_filenames(DEFAULT_ROOT_DIR, DEFAULT_SEARCH_FILENAME)
    for filename in filenames:
        with open(filename) as file:
            lines = file.readlines()

        fixed_lines = [fix_line(line) for line in lines]
        if fixed_lines != lines:
            #print('writing file: ' + filename)
            with open(filename, 'w') as file:
                file.writelines(fixed_lines)
    return 0


if __name__ == '__main__':
    sys.exit(main())
```
